### PR TITLE
docs: add comprehensive README and npm package config

### DIFF
--- a/.changeset/add-readme-and-license.md
+++ b/.changeset/add-readme-and-license.md
@@ -1,0 +1,5 @@
+---
+"agent-react-devtools": patch
+---
+
+Add comprehensive README with usage examples and MIT LICENSE file

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 # Bun
 bun.lock
 
+# Generated at publish time
+packages/agent-react-devtools/README.md
+
 # Examples
 examples/*/node_modules/
 examples/*/dist/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-present Piotr Tomczewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,178 @@
 # agent-react-devtools
 
-CLI tool for AI agents to inspect React component trees and profile rendering performance. Connects to running React apps via the React DevTools protocol.
+Give your AI agent eyes into your React app. Inspect component trees, read props and state, and profile rendering performance — all from the command line. Inspired by Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser) and Callstack's [agent-device](https://github.com/callstackincubator/agent-device).
+
+The project is in early development and considered experimental. Pull requests are welcome!
+
+## Features
+
+- Walk the full component tree with props, state, and hooks
+- Search for components by display name
+- Profile renders: find slow components, excessive re-renders, and commit timelines
+- Persistent background daemon that survives across CLI calls
+- Token-efficient output built for LLM consumption
+
+## Install
+
+```sh
+npm install -g agent-react-devtools
+```
+
+Or run it directly:
+
+```sh
+npx agent-react-devtools start
+```
+
+## Quick Start
+
+```sh
+agent-react-devtools start
+agent-react-devtools status
+```
+
+```
+Daemon: running (port 8097)
+Apps: 1 connected, 24 components
+Uptime: 12s
+```
+
+Browse the component tree:
+
+```sh
+agent-react-devtools get tree --depth 3
+```
+
+```
+@c1 [fn] "App"
+├─ @c2 [fn] "Header"
+│  ├─ @c3 [fn] "Nav"
+│  └─ @c4 [fn] "SearchBar"
+├─ @c5 [fn] "TodoList"
+│  ├─ @c6 [fn] "TodoItem" key="1"
+│  ├─ @c7 [fn] "TodoItem" key="2"
+│  └─ @c8 [fn] "TodoItem" key="3"
+└─ @c9 [fn] "Footer"
+```
+
+Inspect a component's props, state, and hooks:
+
+```sh
+agent-react-devtools get component @c6
+```
+
+```
+@c6 [fn] "TodoItem" key="1"
+props:
+  id: 1
+  text: "Buy groceries"
+  done: false
+  onToggle: ƒ
+hooks:
+  State: false
+  Callback: ƒ
+```
+
+Find components by name:
+
+```sh
+agent-react-devtools find TodoItem
+```
+
+```
+@c6 [fn] "TodoItem" key="1"
+@c7 [fn] "TodoItem" key="2"
+@c8 [fn] "TodoItem" key="3"
+```
+
+Profile rendering performance:
+
+```sh
+agent-react-devtools profile start
+# ... interact with the app ...
+agent-react-devtools profile stop
+agent-react-devtools profile slow
+```
+
+```
+Slowest (by avg render time):
+  TodoList             avg:4.2ms  max:8.1ms  renders:6  cause:props
+  SearchBar            avg:2.1ms  max:3.4ms  renders:12 cause:hooks
+  Header               avg:0.8ms  max:1.2ms  renders:3  cause:parent
+```
+
+## Commands
+
+### Daemon
+
+```sh
+agent-react-devtools start [--port 8097]   # Start daemon
+agent-react-devtools stop                   # Stop daemon
+agent-react-devtools status                 # Connection status
+```
+
+### Components
+
+```sh
+agent-react-devtools get tree [--depth N]          # Component hierarchy
+agent-react-devtools get component <@c1 | id>      # Props, state, hooks
+agent-react-devtools find <name> [--exact]          # Search by display name
+agent-react-devtools count                          # Component count by type
+```
+
+Components are labeled `@c1`, `@c2`, etc. You can use these labels or numeric IDs interchangeably.
+
+### Profiling
+
+```sh
+agent-react-devtools profile start [name]           # Begin a profiling session
+agent-react-devtools profile stop                    # Stop and collect data
+agent-react-devtools profile report <@c1 | id>      # Render report for a component
+agent-react-devtools profile slow [--limit N]        # Slowest components by avg duration
+agent-react-devtools profile rerenders [--limit N]   # Most re-rendered components
+agent-react-devtools profile timeline [--limit N]    # Commit timeline
+agent-react-devtools profile commit <N | #N> [--limit N]  # Single commit detail
+```
+
+## Connecting Your App
+
+Install `react-devtools-core` in your app and connect before React renders (e.g. in `src/main.tsx`):
+
+```ts
+import { initialize, connectToDevTools } from 'react-devtools-core';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+initialize();
+connectToDevTools({ port: 8097 });
+
+createRoot(document.getElementById('root')!).render(<App />);
+```
+
+## Using with AI Agents
+
+Add something like this to your project's `CLAUDE.md` (or equivalent agent instructions):
+
+```markdown
+## React Debugging
+
+This project uses agent-react-devtools to inspect the running React app.
+
+- `agent-react-devtools start` — start the daemon
+- `agent-react-devtools status` — check if the app is connected
+- `agent-react-devtools get tree` — see the component hierarchy
+- `agent-react-devtools get component @c1` — inspect a specific component
+- `agent-react-devtools find <Name>` — search for components
+- `agent-react-devtools profile start` / `profile stop` / `profile slow` — diagnose render performance
+```
 
 ## Development
 
 ```sh
-# Install dependencies
-bun install
-
-# Build
-bun run build
-
-# Run tests
-bun run test
-
-# Type check
-bun run typecheck
+bun install        # Install dependencies
+bun run build      # Build
+bun run test       # Run tests
+bun run typecheck  # Type check
 ```
 
 ## License

--- a/packages/agent-react-devtools/package.json
+++ b/packages/agent-react-devtools/package.json
@@ -6,13 +6,19 @@
   "bin": {
     "agent-react-devtools": "./dist/cli.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "cp ../../README.md ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add full README with installation, quick start, all CLI commands, app connection guide (including Vite workaround), AI agent usage instructions, and architecture diagram
- Configure `package.json` with `files` array and `prepublishOnly` script to copy root README into package directory at publish time
- Add `packages/agent-react-devtools/README.md` to `.gitignore` (generated at publish time)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify `npm pack` includes README in the tarball