### PR TITLE
fix(ci): use calculated version for canary snapshots

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["example-react-app"]
+  "ignore": ["example-react-app"],
+  "snapshot": {
+    "useCalculatedVersion": true
+  }
 }


### PR DESCRIPTION
## Summary
- Add `snapshot.useCalculatedVersion: true` to changeset config
- Canary releases were publishing as `0.0.0-canary-*` because changesets defaults to `0.0.0` as the base version for snapshots
- With this fix, canaries will use the real bumped version (e.g. `0.1.1-canary-TIMESTAMP`)

## Test plan
- [x] Merge and verify next canary publishes with correct version