### PR TITLE
fix: use buildMtime for daemon stale detection, preserve port on restart

### DIFF
--- a/packages/agent-react-devtools/src/daemon-client.ts
+++ b/packages/agent-react-devtools/src/daemon-client.ts
@@ -51,7 +51,11 @@ export async function ensureDaemon(port?: number): Promise<void> {
     );
     try {
       const stat = fs.statSync(daemonScript);
-      if (stat.mtimeMs > info.startedAt) {
+      const stale = info.buildMtime !== undefined
+        ? stat.mtimeMs !== info.buildMtime
+        : stat.mtimeMs > info.startedAt;
+      if (stale) {
+        port = port ?? info.port;
         stopDaemon();
       } else {
         return;

--- a/packages/agent-react-devtools/src/daemon.ts
+++ b/packages/agent-react-devtools/src/daemon.ts
@@ -73,11 +73,18 @@ class Daemon {
     await this.startIpc(socketPath);
 
     // Write daemon info
+    let buildMtime: number | undefined;
+    try {
+      buildMtime = fs.statSync(new URL(import.meta.url).pathname).mtimeMs;
+    } catch {
+      // ignore
+    }
     const info: DaemonInfo = {
       pid: process.pid,
       port: this.port,
       socketPath,
       startedAt: this.startedAt,
+      buildMtime,
     };
     fs.writeFileSync(getDaemonInfoPath(), JSON.stringify(info, null, 2));
 

--- a/packages/agent-react-devtools/src/types.ts
+++ b/packages/agent-react-devtools/src/types.ts
@@ -143,6 +143,8 @@ export interface DaemonInfo {
   port: number;
   socketPath: string;
   startedAt: number;
+  /** mtime of daemon.js when the daemon was spawned */
+  buildMtime?: number;
 }
 
 export interface StatusInfo {

--- a/packages/e2e-tests/src/daemon-auto-restart.test.ts
+++ b/packages/e2e-tests/src/daemon-auto-restart.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  createTempStateDir,
+  getTestPort,
+  runCli,
+} from './helpers.js';
+
+describe('Daemon auto-restart on rebuild', () => {
+  let stateDir: string;
+  let port: number;
+
+  beforeEach(async () => {
+    stateDir = createTempStateDir();
+    port = getTestPort();
+
+    const result = await runCli(['start', `--port`, `${port}`], stateDir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  afterEach(async () => {
+    await runCli(['stop'], stateDir);
+    try {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('should restart daemon when daemon.js has been rebuilt', async () => {
+    const infoPath = path.join(stateDir, 'daemon.json');
+    const infoBefore = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+
+    // Simulate a rebuild by changing the stored buildMtime so it no longer
+    // matches the actual daemon.js mtime
+    infoBefore.buildMtime = 1000;
+    fs.writeFileSync(infoPath, JSON.stringify(infoBefore, null, 2));
+
+    const result = await runCli(['get', 'tree'], stateDir);
+    expect(result.exitCode).toBe(0);
+
+    const infoAfter = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+    expect(infoAfter.pid).not.toBe(infoBefore.pid);
+    expect(infoAfter.port).toBe(port);
+  });
+
+  it('should not restart when daemon is up to date', async () => {
+    const infoPath = path.join(stateDir, 'daemon.json');
+    const infoBefore = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+
+    const result = await runCli(['get', 'tree'], stateDir);
+    expect(result.exitCode).toBe(0);
+
+    const infoAfter = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+    expect(infoAfter.pid).toBe(infoBefore.pid);
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to #41 which introduced daemon auto-restart but had two bugs:

1. **Port lost on restart** — `ensureDaemon()` restarted the daemon with `port = undefined` (most CLI commands don't pass a port), silently switching to 8097. Now preserves the original `info.port`.

2. **False restarts in CI** — comparing `daemon.js` mtime against `startedAt` was fragile: when build and daemon start happened close together, filesystem timestamp precision could make them appear out of order.

### New approach
The daemon now records `daemon.js`'s mtime at startup as `buildMtime` in `daemon.json`. The CLI compares the file's current mtime against this stored value — if they differ, the file was rebuilt and the daemon restarts. No tolerance or clock comparison needed.

### Changes
- `DaemonInfo` gains optional `buildMtime` field
- Daemon writes `daemon.js` mtime to `daemon.json` on startup
- `ensureDaemon()` compares current mtime vs stored `buildMtime`
- Port is preserved from `info.port` when restarting

### E2E test
New `daemon-auto-restart.test.ts` uses the full CLI lifecycle (`start`/`stop`/`get tree`) to verify:
- Daemon restarts (new PID, same port) when `buildMtime` doesn't match
- Daemon stays alive when `buildMtime` matches

## Test plan
- [x] 68 unit tests pass
- [x] 34 e2e tests pass (including new auto-restart tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)