### PR TITLE
docs: add profile export and profile diff commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ agent-react-devtools profile slow [--limit N]        # Slowest components by avg
 agent-react-devtools profile rerenders [--limit N]   # Most re-rendered components
 agent-react-devtools profile timeline [--limit N]    # Commit timeline
 agent-react-devtools profile commit <N | #N> [--limit N]  # Single commit detail
+agent-react-devtools profile export <file>               # Export as React DevTools Profiler JSON
+agent-react-devtools profile diff <before.json> <after.json> [--limit N] [--threshold N]  # Compare two exports
 ```
 
 ## Connecting Your App

--- a/packages/agent-react-devtools/skills/react-devtools/SKILL.md
+++ b/packages/agent-react-devtools/skills/react-devtools/SKILL.md
@@ -49,6 +49,8 @@ agent-react-devtools profile rerenders          # Most re-rendered components
 agent-react-devtools profile report @c5         # Detailed report for one component
 agent-react-devtools profile timeline           # Chronological commit list
 agent-react-devtools profile commit 3           # Detail for commit #3
+agent-react-devtools profile export profile.json # Export as React DevTools Profiler JSON
+agent-react-devtools profile diff before.json after.json  # Compare two exports
 ```
 
 ## Understanding the Output

--- a/packages/agent-react-devtools/skills/react-devtools/references/commands.md
+++ b/packages/agent-react-devtools/skills/react-devtools/references/commands.md
@@ -81,6 +81,12 @@ Chronological list of React commits during the profiling session. Each entry: in
 ### `agent-react-devtools profile commit <N | #N> [--limit N]`
 Detail for a specific commit by index. Shows per-component self/total duration, render causes, and changed keys.
 
+### `agent-react-devtools profile export <file>`
+Export profiling data as a JSON file importable in the React DevTools Profiler tab. The file can also be used as input to `profile diff`. Requires an active or recently stopped profiling session.
+
+### `agent-react-devtools profile diff <before.json> <after.json> [--limit N] [--threshold N]`
+Compare two exported profiling sessions and show regressed, improved, new, and removed components. Default threshold: 5% — changes below this percentage are not reported. Use `--limit N` to cap the number of components shown per category. Does **not** require the daemon to be running.
+
 ### Changed Keys
 
 When React DevTools reports which specific props, state keys, or hooks triggered a re-render, profiling commands append a `changed:` suffix:

--- a/packages/agent-react-devtools/skills/react-devtools/references/profiling-guide.md
+++ b/packages/agent-react-devtools/skills/react-devtools/references/profiling-guide.md
@@ -95,6 +95,40 @@ agent-react-devtools profile slow --limit 5
 
 Compare render counts and durations to confirm improvement.
 
+## Export and Diff Workflow
+
+### Export Profiling Data
+
+After stopping a profiling session, export the data to a JSON file. This file can be imported into the React DevTools Profiler tab for visual analysis, or used as input to `profile diff`.
+
+```bash
+agent-react-devtools profile stop
+agent-react-devtools profile export baseline.json
+```
+
+### Compare Two Profiling Sessions
+
+To identify regressions or verify improvements, export profiles before and after a change, then diff them:
+
+```bash
+# Before the change
+agent-react-devtools profile start "before"
+# ... interact with the app ...
+agent-react-devtools profile stop
+agent-react-devtools profile export before.json
+
+# After the change
+agent-react-devtools profile start "after"
+# ... same interaction ...
+agent-react-devtools profile stop
+agent-react-devtools profile export after.json
+
+# Compare
+agent-react-devtools profile diff before.json after.json
+```
+
+The diff shows regressed, improved, new, and removed components. Use `--threshold` to adjust sensitivity (default: 5%) and `--limit` to cap the number of components per category.
+
 ## Common Performance Issues
 
 ### Cascading re-renders from context or lifted state


### PR DESCRIPTION
## Summary
- Add `profile export` and `profile diff` commands to README, skill definition, commands reference, and profiling guide
- Documents the `--threshold` flag and that `profile diff` doesn't require the daemon

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify skill docs are picked up by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)