### PR TITLE
fix: update browser e2e get-tree assertion to match new response shape

### DIFF
--- a/packages/e2e-tests/src/browser.test.ts
+++ b/packages/e2e-tests/src/browser.test.ts
@@ -71,7 +71,7 @@ describe('Browser e2e', () => {
   it('get-tree returns real component hierarchy', async () => {
     const resp = await sendIpcCommand(socketPath, { type: 'get-tree' });
     expect(resp.ok).toBe(true);
-    const nodes = resp.data as Array<{ displayName: string; type: string; label: string }>;
+    const { nodes } = resp.data as { nodes: Array<{ displayName: string; type: string; label: string }> };
     expect(nodes.length).toBeGreaterThan(5);
 
     const names = nodes.map((n) => n.displayName);


### PR DESCRIPTION
## Summary

- PR #45 changed the `get-tree` IPC response from a flat array to `{ nodes, totalCount }`, but `browser.test.ts` was not updated to match
- This caused the Release workflow to fail on every push to main with `TypeError: actual value must be number or bigint, received "undefined"` at `browser.test.ts:75`
- The protocol E2E test was already correctly updated in #45; only the browser test was missed

## Why the PR didn't catch it

The `ci.yml` workflow (which runs on PRs) does not include browser E2E tests — they only run in `release.yml` on push to main, so the regression slipped through.

## Test plan

- [x] Release workflow `E2E tests (browser)` passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)