### PR TITLE
ci: run browser e2e tests in merge queue only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, changeset-release/main]
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   typecheck:
@@ -41,6 +42,20 @@ jobs:
       - run: bun install
       - run: bun run build
       - run: bun run --filter e2e-tests test:protocol
+
+  e2e-browser:
+    name: E2E tests (browser)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'merge_group'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run build
+      - run: npx --prefix packages/e2e-tests playwright install --with-deps chromium
+      - run: bun run --filter e2e-tests test:browser
 
   cli-smoke:
     name: CLI smoke test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,6 @@ jobs:
       - name: E2E tests (protocol)
         run: bun run --filter e2e-tests test:protocol
 
-      - name: Install Playwright
-        run: npx --prefix packages/e2e-tests playwright install --with-deps chromium
-
-      - name: E2E tests (browser)
-        run: bun run --filter e2e-tests test:browser
-
       - name: Create release PR or publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary

- Adds `merge_group` trigger to `ci.yml` and a new **E2E tests (browser)** job that only runs when a PR enters the merge queue — not on every push
- Removes the duplicate browser E2E steps from `release.yml` (redundant once the merge queue gate is in place)

## How it works

```
PR push  →  typecheck + unit tests + protocol e2e + cli smoke  (fast, runs every commit)
Merge queue  →  all of the above + browser e2e  (runs once before landing)
```

Nothing broken can reach `main` without the browser tests passing, and they don't slow down normal development.

## Required: enable merge queue in repo settings

After merging this PR, go to **Settings → Branches → branch protection for `main`** and:
1. Enable **"Require merge queue"**
2. Add **"E2E tests (browser)"** as a required status check for the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)