### PR TITLE
chore: update repository URL to callstackincubator org

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ agent-react-devtools status  # Should show "Apps: 1 connected"
 Add the skill to your AI coding assistant for richer context:
 
 ```sh
-npx skills add piotrski/agent-react-devtools
+npx skills add callstackincubator/agent-react-devtools
 ```
 
 This works with Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, Goose, OpenCode, and Windsurf.
@@ -282,7 +282,7 @@ This works with Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, Goose, O
 You can also install via the Claude Code plugin marketplace:
 
 ```
-/plugin marketplace add piotrski/agent-react-devtools
+/plugin marketplace add callstackincubator/agent-react-devtools
 /plugin install agent-react-devtools@piotrski
 ```
 

--- a/packages/agent-react-devtools/package.json
+++ b/packages/agent-react-devtools/package.json
@@ -34,7 +34,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/piotrski/agent-react-devtools.git",
+    "url": "https://github.com/callstackincubator/agent-react-devtools.git",
     "directory": "packages/agent-react-devtools"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Updates `repository.url` in `package.json` from `piotrski/agent-react-devtools` to `callstackincubator/agent-react-devtools`
- Updates skill install commands in `README.md` to match

## Why

npm's OIDC trusted publishing validates the repository in the provenance claim against the `repository` field in `package.json`. Since the package moved to the `callstackincubator` org but the field wasn't updated, every canary publish attempt fails with `ENEEDAUTH` the OIDC claims don't match what npmjs.com expects.