### PR TITLE
feat: add contributor attribution to changelog

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "callstackincubator/agent-react-devtools" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "release": "bun run build && changeset publish"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.27.0"
   }
 }


### PR DESCRIPTION
## Summary

- Installs `@changesets/changelog-github`
- Switches the changelog generator in `.changeset/config.json` from the default to `@changesets/changelog-github`

## Result

Future changelog entries will include contributor names and PR links, e.g.:

> ### Minor Changes
> - `a1bed65`: Smart tree truncation and subtree extraction — thanks @piotrski! ([#45](https://github.com/callstackincubator/agent-react-devtools/pull/45))

No other changes needed — `GITHUB_TOKEN` is already passed to the `changesets/action` step in `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)